### PR TITLE
Remove postgres reference in the create table sql

### DIFF
--- a/internal/server/sql/migration/migratetokens.go
+++ b/internal/server/sql/migration/migratetokens.go
@@ -14,7 +14,5 @@ const (
 );
 
 create index "Token_username_index"
-    on "Token" (username);
-
-`
+    on "Token" (username);`
 )

--- a/internal/server/sql/migration/migrateusers.go
+++ b/internal/server/sql/migration/migrateusers.go
@@ -13,9 +13,6 @@ const (
     access_groups   text[]
 );
 
-alter table "User"
-    owner to postgres;
-
 create unique index "User_username_index"
     on "User" (username);`
 )


### PR DESCRIPTION
## What's this change for?
This fixes the lack of privilege error that occurs during table creation.

Related to #36 

# Error

```
/###/internal/server/sql/migration/migration.go#24: &{{}}: error: ERROR: must be member of role "postgres" (SQLSTATE 42501)
create table "User"
(
    primary_id      uuid not null
        constraint "User_pk"
            primary key,
    username        varchar(50)
        constraint "User_pk2"
            unique,
    hashed_password varchar(60),
    access_groups   text[]
);

alter table "User"
    owner to postgres;

create unique index "User_username_index"
    on "User" (username);
2022/12/29 19:09:19 ERROR: must be member of role "postgres" (SQLSTATE 42501)
```

The problematic part of the SQL command is:
```
alter table "User"
    owner to postgres;
```