### PR TITLE
Allow auth and content-type headers

### DIFF
--- a/docs/docs/infrastructure.md
+++ b/docs/docs/infrastructure.md
@@ -1,0 +1,6 @@
+# Infrastructure
+
+## Environment variables (prod and local)
+
+// todo: improve documentation
+CORS_ALLOWLIST: ["a.com"]

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -4,3 +4,4 @@ nav:
   - Onboarding: onboarding.md
   - Private workflow: private_workflow.md
   - Code standards: code_standards.md
+  - Infrastructure: infrastructure.md

--- a/internal/server/mux.go
+++ b/internal/server/mux.go
@@ -89,6 +89,10 @@ func RunServeMux(s *Server, flags *models.RunFlags) {
 		AllowedOrigins:   flags.CorsAllowList,
 		AllowCredentials: false,
 		Debug:            true,
+		AllowedHeaders: []string{
+			"Content-Type",
+			"Authorization",
+		},
 	})
 	corsHandler := c.Handler(authWrapper)
 

--- a/internal/storage/contents_postgres.go
+++ b/internal/storage/contents_postgres.go
@@ -130,24 +130,30 @@ func (c *contentsPostgresImpl) GetContentById(ctx context.Context, idQuery strin
 	return &content, nil
 }
 
+func derefString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
 func (c *contentsPostgresImpl) GetAllContent(ctx context.Context) ([]*turnip.Content, error) {
 	contentList := []*turnip.Content{}
 
 	// todo: handle paging
 	var primaryId, authorId pgtype.UUID
 	var createdAt pgtype.Timestamp
-	var title, description, content string
+	var title, description, content, accessDetails, meta *string
 	var tagList []string
-	var accessDetails, meta string
 
 	rows, _ := c.db.Pool.Query(ctx, `SELECT * FROM "Content"`)
 	_, err := pgx.ForEachRow(rows, []any{&primaryId, &createdAt, &title, &description, &content,
 		&tagList, &accessDetails, &meta, &authorId}, func() error {
-		// todo: check if access, otherwise add to list
+		// todo: check if accessible, otherwise add to list
 		newContent := &turnip.Content{
-			Title:         title,
-			Description:   description,
-			Content:       content,
+			Title:         derefString(title),
+			Description:   derefString(description),
+			Content:       derefString(content),
 			TagList:       tagList,
 			AccessDetails: nil, // todo parse
 			Meta:          nil, // todo parse


### PR DESCRIPTION
## Changes
Related to https://github.com/TurnipXenon/potato/issues/4

When we push on potato, we want to make sure we don't encounter a CORS error.